### PR TITLE
docs: Fix unclosed curly bracket

### DIFF
--- a/docs/sparse_retriever.md
+++ b/docs/sparse_retriever.md
@@ -67,7 +67,7 @@ sr = sr.index_file(
   callback=lambda doc: {      # Callback defaults to None.
     "id": doc["id"],
     "text": doc["title"] + ". " + doc["text"],          
-  )
+  })
 ```
 
 ### Load


### PR DESCRIPTION
## Description

The index_file callback example in the Sparse retriver docs was missing a closing curly brace.